### PR TITLE
Enable external change of repeat count value and support animator listeners

### DIFF
--- a/shimmer/src/main/java/com/facebook/shimmer/ShimmerDrawable.java
+++ b/shimmer/src/main/java/com/facebook/shimmer/ShimmerDrawable.java
@@ -8,6 +8,7 @@
 
 package com.facebook.shimmer;
 
+import android.animation.Animator;
 import android.animation.ValueAnimator;
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;
@@ -22,6 +23,7 @@ import android.graphics.Rect;
 import android.graphics.Shader;
 import android.graphics.drawable.Drawable;
 import android.view.animation.LinearInterpolator;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -169,6 +171,34 @@ public final class ShimmerDrawable extends Drawable {
     return mShimmer != null && (mShimmer.clipToChildren || mShimmer.alphaShimmer)
         ? PixelFormat.TRANSLUCENT
         : PixelFormat.OPAQUE;
+  }
+
+  public void setRepeatCount(int count) {
+    if (mValueAnimator != null) {
+      mValueAnimator.setRepeatCount(count);
+    }
+  }
+
+  public int getRepeatCount() {
+    return mValueAnimator != null ? mValueAnimator.getRepeatCount() : 0;
+  }
+
+  public void addAnimatorListener(Animator.AnimatorListener listener) {
+    if (mValueAnimator != null) {
+      mValueAnimator.addListener(listener);
+    }
+  }
+
+  public void removeAnimatorListener(Animator.AnimatorListener listener) {
+    if (mValueAnimator != null) {
+      mValueAnimator.removeListener(listener);
+    }
+  }
+
+  public void removeAllAnimatorListeners() {
+    if (mValueAnimator != null) {
+      mValueAnimator.removeAllListeners();
+    }
   }
 
   private float offset(float start, float end, float percent) {

--- a/shimmer/src/main/java/com/facebook/shimmer/ShimmerFrameLayout.java
+++ b/shimmer/src/main/java/com/facebook/shimmer/ShimmerFrameLayout.java
@@ -8,6 +8,7 @@
 
 package com.facebook.shimmer;
 
+import android.animation.Animator;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.TypedArray;
@@ -201,4 +202,25 @@ public class ShimmerFrameLayout extends FrameLayout {
   public void clearStaticAnimationProgress() {
     mShimmerDrawable.clearStaticAnimationProgress();
   }
+
+  public void addAnimatorListener(Animator.AnimatorListener listener) {
+    mShimmerDrawable.addAnimatorListener(listener);
+  }
+
+  public void removeAnimatorListener(Animator.AnimatorListener listener) {
+    mShimmerDrawable.removeAnimatorListener(listener);
+  }
+
+  public void removeAllAnimatorListeners() {
+    mShimmerDrawable.removeAllAnimatorListeners();
+  }
+
+  public void setRepeatCount(int count) {
+    mShimmerDrawable.setRepeatCount(count);
+  }
+
+  public int getRepeatCount() {
+    return mShimmerDrawable.getRepeatCount();
+  }
+
 }


### PR DESCRIPTION

This change allows users of `ShimmerFrameLayout` to query/change a value of repetitions count and add/remove animator listeners.

With these changes users will be able to update a shimmer effect when the current animation (or repetition cycle) is finished.